### PR TITLE
５回同様のステータスを入力すると『NG』と言うステータスへ変更　Feature/add ng to status

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -45,7 +45,11 @@ class CallsController < ApplicationController
       end
       @call.save
       #@call.update_attribute(:customer_tel, @customer.tel)
-      redirect_to customer_path(id: @next_customer.id, q: params[:q]&.permit!, last_call: params[:last_call]&.permit!)
+      if @next_customer.present?
+        redirect_to customer_path(id: @next_customer.id, q: params[:q]&.permit!, last_call: params[:last_call]&.permit!)
+      else
+        redirect_to customer_path(id: @customer.id, q: params[:q]&.permit!, last_call: params[:last_call]&.permit!)
+      end
   end
 
   def update

--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -33,10 +33,19 @@ class CallsController < ApplicationController
   end
 
   def create
-    if @call = @customer.calls.create(call_params)
-    #@call.update_attribute(:customer_tel, @customer.tel)
+    @call = @customer.calls.new(call_params)
+      if @customer.calls.count >= 4
+        # 最新のステータスが着信留守4回連続の場合、5回目はNGとする
+        if @customer.calls.order(created_at: :desc).limit(4).pluck(:statu).all? { |w| w == "着信留守"  }
+          if @call.statu == "着信留守"
+            @call.statu = "NG"
+            @call.save
+          end
+        end
+      end
+      @call.save
+      #@call.update_attribute(:customer_tel, @customer.tel)
       redirect_to customer_path(id: @next_customer.id, q: params[:q]&.permit!, last_call: params[:last_call]&.permit!)
-    end
   end
 
   def update

--- a/app/views/customers/_show.html.erb
+++ b/app/views/customers/_show.html.erb
@@ -125,7 +125,6 @@
 </table>
 <%end%>
 </div>
-<%end%>
 
 <table width="100%" class="space">
 		<col width="15%">


### PR DESCRIPTION
**実装内容**
・userログイン時のcustomers/:idページにて、5回目の着信留守で、NGというステータス作成
・customers/_showページのエラー解消
・customers/:idが最終ページの時に新規ステータス作成に伴うページ遷移時のエラー解消

**できるようになること（ユーザ目線）**
・5回目の着信留守で、NGというステータス作成

**動作確認**
・5回連続で着信留守とした場合にNGステータス発行されるか確認
・他のステータスが5回連続で入力された際にはNGとされない事を確認

その他
レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
画像
<img width="1440" alt="スクリーンショット 2021-01-19 10 15 37" src="https://user-images.githubusercontent.com/68761051/104975917-562a8a00-5a3f-11eb-8a99-a53dffd2f429.png">
