### PR TITLE
速度改善　Fix/speed improvement

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -116,23 +116,48 @@ class CustomersController < ApplicationController
    @customers =  Customer.all
    @customers_app = @customers.where(call_id: 1)
    #today
-   @call_count_today  = @calls.where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
-   @protect_count_today = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
+  #  @call_count_today  = @calls.where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
+  #  @protect_count_today = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
+  #  @protect_convertion_today = (@protect_count_today.to_f / @call_count_today.to_f) * 100
+  #  @app_count_today = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
+  #  @app_convertion_today = (@app_count_today.to_f / @call_count_today.to_f) * 100
+
+   @call_today_basic = @calls.where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).to_a
+   @call_count_today = @call_today_basic.count
+   @protect_count_today = @call_today_basic.select { |statu| statu == "見込" }.count
    @protect_convertion_today = (@protect_count_today.to_f / @call_count_today.to_f) * 100
-   @app_count_today = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
+   @app_count_today = @call_today_basic.select { |statu| statu == "APP" }.count
    @app_convertion_today = (@app_count_today.to_f / @call_count_today.to_f) * 100
+
+  #  binding.pry
    #week
-   @call_count_week  = @calls.where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
-   @protect_count_week = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
+  #  @call_count_week  = @calls.where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
+  #  @protect_count_week = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
+  #  @protect_convertion_week = (@protect_count_week.to_f / @call_count_week.to_f) * 100
+  #  @app_count_week = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
+  #  @app_convertion_week = (@app_count_week.to_f / @call_count_week.to_f) * 100
+
+   @call_week_basic = @calls.where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).to_a
+   @call_count_week = @call_week_basic.count
+   @protect_count_week = @call_week_basic.select { |statu| statu == "見込" }.count
    @protect_convertion_week = (@protect_count_week.to_f / @call_count_week.to_f) * 100
-   @app_count_week = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
+   @app_count_week = @call_week_basic.select { |statu| statu == "APP" }.count
    @app_convertion_week = (@app_count_week.to_f / @call_count_week.to_f) * 100
+
    #month
-   @call_count_month = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_day).count
-   @protect_count_month = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count
+  #  @call_count_month = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_day).count
+  #  @protect_count_month = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count
+  #  @protect_convertion_month = (@protect_count_month.to_f / @call_count_month.to_f) * 100
+  #  @app_count_month = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count
+  #  @app_convertion_month = (@app_count_month.to_f / @call_count_month.to_f) * 100
+
+   @call_month_basic = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).to_a
+   @call_count_month = @call_month_basic.count
+   @protect_count_month = @call_month_basic.select { |statu| statu == "見込" }.count
    @protect_convertion_month = (@protect_count_month.to_f / @call_count_month.to_f) * 100
-   @app_count_month = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count
+   @app_count_month = @call_month_basic.select { |statu| statu == "APP" }.count
    @app_convertion_month = (@app_count_month.to_f / @call_count_month.to_f) * 100
+
    @admins = Admin.all
    @users = User.all
    #statu内容簡素化

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -121,12 +121,12 @@ class CustomersController < ApplicationController
   #  @protect_convertion_today = (@protect_count_today.to_f / @call_count_today.to_f) * 100
   #  @app_count_today = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
   #  @app_convertion_today = (@app_count_today.to_f / @call_count_today.to_f) * 100
-
+  # today改善後
    @call_today_basic = @calls.where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).to_a
    @call_count_today = @call_today_basic.count
-   @protect_count_today = @call_today_basic.select { |statu| statu == "見込" }.count
+   @protect_count_today = @call_today_basic.select { |call| call.statu == "見込" }.count
    @protect_convertion_today = (@protect_count_today.to_f / @call_count_today.to_f) * 100
-   @app_count_today = @call_today_basic.select { |statu| statu == "APP" }.count
+   @app_count_today = @call_today_basic.select { |call| call.statu == "APP" }.count
    @app_convertion_today = (@app_count_today.to_f / @call_count_today.to_f) * 100
 
   #  binding.pry
@@ -136,12 +136,12 @@ class CustomersController < ApplicationController
   #  @protect_convertion_week = (@protect_count_week.to_f / @call_count_week.to_f) * 100
   #  @app_count_week = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
   #  @app_convertion_week = (@app_count_week.to_f / @call_count_week.to_f) * 100
-
+  # week改善後
    @call_week_basic = @calls.where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).to_a
    @call_count_week = @call_week_basic.count
-   @protect_count_week = @call_week_basic.select { |statu| statu == "見込" }.count
+   @protect_count_week = @call_week_basic.select { |call| call.statu == "見込" }.count
    @protect_convertion_week = (@protect_count_week.to_f / @call_count_week.to_f) * 100
-   @app_count_week = @call_week_basic.select { |statu| statu == "APP" }.count
+   @app_count_week = @call_week_basic.select { |call| call.statu == "APP" }.count
    @app_convertion_week = (@app_count_week.to_f / @call_count_week.to_f) * 100
 
    #month
@@ -150,14 +150,21 @@ class CustomersController < ApplicationController
   #  @protect_convertion_month = (@protect_count_month.to_f / @call_count_month.to_f) * 100
   #  @app_count_month = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count
   #  @app_convertion_month = (@app_count_month.to_f / @call_count_month.to_f) * 100
-
+  # month改善後
    @call_month_basic = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).to_a
    @call_count_month = @call_month_basic.count
-   @protect_count_month = @call_month_basic.select { |statu| statu == "見込" }.count
+   @protect_count_month = @call_month_basic.select { |call| call.statu == "見込" }.count
    @protect_convertion_month = (@protect_count_month.to_f / @call_count_month.to_f) * 100
-   @app_count_month = @call_month_basic.select { |statu| statu == "APP" }.count
+   @app_count_month = @call_month_basic.select { |call| call.statu == "APP" }.count
    @app_convertion_month = (@app_count_month.to_f / @call_count_month.to_f) * 100
 
+  #  ステータス別結果
+   @call_count_called = @call_month_basic.select { |call| call.statu == "着信留守" }.count
+   @call_count_absence = @call_month_basic.select { |call| call.statu == "担当者不在" }.count
+   @call_count_prospect = @call_month_basic.select { |call| call.statu == "見込" }.count
+   @call_count_app = @call_month_basic.select { |call| call.statu == "APP" }.count
+   @call_count_cancel = @call_month_basic.select { |call| call.statu == "キャンセル" }.count
+   @call_count_ng = @call_month_basic.select { |call| call.statu == "NG" }.count
    @admins = Admin.all
    @users = User.all
    #statu内容簡素化

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -84,156 +84,252 @@ class CustomersController < ApplicationController
     @customer = Customer.find(params[:id])
   end
 
- def update
+  def update
     @customers = Customer&.where(worker_id: current_worker.id)
     @count_day = @customers.where('updated_at > ?', Time.current.beginning_of_day).where('updated_at < ?',Time.current.end_of_day).count
     @customer = Customer.find(params[:id])
-     if @customer.update(customer_params)
-       flash[:notice] = "登録が完了しました。1日あたりの残り作業実施件数は#{30 - @count_day}件です。"
-       redirect_to customer_path
-     else
-       render 'edit'
-     end
- end
+      if @customer.update(customer_params)
+        flash[:notice] = "登録が完了しました。1日あたりの残り作業実施件数は#{30 - @count_day}件です。"
+        redirect_to customer_path
+      else
+        render 'edit'
+      end
+  end
 
- def destroy
+  def destroy
     @customer = Customer.find(params[:id])
     @customer.destroy
     redirect_to customers_path
- end
-
- def destroy_all
-   checked_data = params[:deletes].keys #checkデータを受け取る
-   if Customer.destroy(checked_data)
-     redirect_to customers_path
-   else
-     render action: 'index'
-   end
- end
-
- def analytics
-   @calls = Call.all
-   @customers =  Customer.all
-   @customers_app = @customers.where(call_id: 1)
-   #today
-  #  @call_count_today  = @calls.where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
-  #  @protect_count_today = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
-  #  @protect_convertion_today = (@protect_count_today.to_f / @call_count_today.to_f) * 100
-  #  @app_count_today = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).count
-  #  @app_convertion_today = (@app_count_today.to_f / @call_count_today.to_f) * 100
-  # today改善後
-   @call_today_basic = @calls.where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).to_a
-   @call_count_today = @call_today_basic.count
-   @protect_count_today = @call_today_basic.select { |call| call.statu == "見込" }.count
-   @protect_convertion_today = (@protect_count_today.to_f / @call_count_today.to_f) * 100
-   @app_count_today = @call_today_basic.select { |call| call.statu == "APP" }.count
-   @app_convertion_today = (@app_count_today.to_f / @call_count_today.to_f) * 100
-
-  #  binding.pry
-   #week
-  #  @call_count_week  = @calls.where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
-  #  @protect_count_week = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
-  #  @protect_convertion_week = (@protect_count_week.to_f / @call_count_week.to_f) * 100
-  #  @app_count_week = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).count
-  #  @app_convertion_week = (@app_count_week.to_f / @call_count_week.to_f) * 100
-  # week改善後
-   @call_week_basic = @calls.where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).to_a
-   @call_count_week = @call_week_basic.count
-   @protect_count_week = @call_week_basic.select { |call| call.statu == "見込" }.count
-   @protect_convertion_week = (@protect_count_week.to_f / @call_count_week.to_f) * 100
-   @app_count_week = @call_week_basic.select { |call| call.statu == "APP" }.count
-   @app_convertion_week = (@app_count_week.to_f / @call_count_week.to_f) * 100
-
-   #month
-  #  @call_count_month = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_day).count
-  #  @protect_count_month = @calls.where(statu: "見込").where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count
-  #  @protect_convertion_month = (@protect_count_month.to_f / @call_count_month.to_f) * 100
-  #  @app_count_month = @calls.where(statu: "APP").where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count
-  #  @app_convertion_month = (@app_count_month.to_f / @call_count_month.to_f) * 100
-  # month改善後
-   @call_month_basic = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).to_a
-   @call_count_month = @call_month_basic.count
-   @protect_count_month = @call_month_basic.select { |call| call.statu == "見込" }.count
-   @protect_convertion_month = (@protect_count_month.to_f / @call_count_month.to_f) * 100
-   @app_count_month = @call_month_basic.select { |call| call.statu == "APP" }.count
-   @app_convertion_month = (@app_count_month.to_f / @call_count_month.to_f) * 100
-
-  #  ステータス別結果
-   @call_count_called = @call_month_basic.select { |call| call.statu == "着信留守" }.count
-   @call_count_absence = @call_month_basic.select { |call| call.statu == "担当者不在" }.count
-   @call_count_prospect = @call_month_basic.select { |call| call.statu == "見込" }.count
-   @call_count_app = @call_month_basic.select { |call| call.statu == "APP" }.count
-   @call_count_cancel = @call_month_basic.select { |call| call.statu == "キャンセル" }.count
-   @call_count_ng = @call_month_basic.select { |call| call.statu == "NG" }.count
-   @admins = Admin.all
-   @users = User.all
-   #statu内容簡素化
-   @call_count = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month)
-   #detail calls
-   @detailcalls = Customer2.joins(:calls).select('calls.id')
-
-   call_attributes = ["customer_id" ,"statu", "time", "comment", "created_at","updated_at"]
-   generate_call =
-     CSV.generate(headers:true) do |csv|
-       csv << call_attributes
-       Call.all.each do |task|
-         csv << call_attributes.map{|attr| task.send(attr)}
-       end
-     end
-   respond_to do |format|
-    format.html
-    format.csv{ send_data generate_call, filename: "calls-#{Time.zone.now.strftime('%Y%m%d%S')}.csv" }
   end
- end
 
- def import
-   cnt = Customer.import(params[:file])
-   redirect_to customers_url, notice:"#{cnt}件登録されました。"
- end
+  def destroy_all
+    checked_data = params[:deletes].keys #checkデータを受け取る
+    if Customer.destroy(checked_data)
+      redirect_to customers_path
+    else
+      render action: 'index'
+    end
+  end
 
- def call_import
-   cnt = Call.call_import(params[:call_file])
-   redirect_to customers_url, notice:"#{cnt}件登録されました。"
- end
+  def analytics
+    @calls = Call.all
+    @customers =  Customer.all
+    @customers_app = @customers.where(call_id: 1)
+    #today
+    @call_today_basic = @calls.where('created_at > ?', Time.current.beginning_of_day).where('created_at < ?', Time.current.end_of_day).to_a
+    @call_count_today = @call_today_basic.count
+    @protect_count_today = @call_today_basic.select { |call| call.statu == "見込" }.count
+    @protect_convertion_today = (@protect_count_today.to_f / @call_count_today.to_f) * 100
+    @app_count_today = @call_today_basic.select { |call| call.statu == "APP" }.count
+    @app_convertion_today = (@app_count_today.to_f / @call_count_today.to_f) * 100
 
- def confirm
-   @customer = Customer.new(customer_params)
-   if @customer.valid?
-     render :action =>  'confirm', notice: 'メッセージが送信されました。'
-   else
-     render :action => 'index', notice: 'メッセージが送信出来ませんでした。'
-   end
- end
+    #week
+    @call_week_basic = @calls.where('created_at > ?', Time.current.beginning_of_week).where('created_at < ?', Time.current.end_of_week).to_a
+    @call_count_week = @call_week_basic.count
+    @protect_count_week = @call_week_basic.select { |call| call.statu == "見込" }.count
+    @protect_convertion_week = (@protect_count_week.to_f / @call_count_week.to_f) * 100
+    @app_count_week = @call_week_basic.select { |call| call.statu == "APP" }.count
+    @app_convertion_week = (@app_count_week.to_f / @call_count_week.to_f) * 100
 
- def thanks
-   @customer = Customer.find(params[:id])
-   CustomerMailer.received_email(@customer).deliver
-   CustomerMailer.send_email(@customer).deliver
- end
+    #month
+    @call_month_basic = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).to_a
+    @call_count_month = @call_month_basic.count
+    @protect_count_month = @call_month_basic.select { |call| call.statu == "見込" }.count
+    @protect_convertion_month = (@protect_count_month.to_f / @call_count_month.to_f) * 100
+    @app_count_month = @call_month_basic.select { |call| call.statu == "APP" }.count
+    @app_convertion_month = (@app_count_month.to_f / @call_count_month.to_f) * 100
 
- def sfa
-   @q = Customer.ransack(params[:q])
-   @customers = @q.result
-   @customers = Customer.where(choice: "SFA").page(params[:page]).per(20)
- end
+    #  ステータス別結果
+    @call_count_called = @call_month_basic.select { |call| call.statu == "着信留守" }
+    @call_count_absence = @call_month_basic.select { |call| call.statu == "担当者不在" }
+    @call_count_prospect = @call_month_basic.select { |call| call.statu == "見込" }
+    @call_count_app = @call_month_basic.select { |call| call.statu == "APP" }
+    @call_count_cancel = @call_month_basic.select { |call| call.statu == "キャンセル" }
+    @call_count_ng = @call_month_basic.select { |call| call.statu == "NG" }
 
- def list
-   @q = Customer.ransack(params[:q])
-   @customers = @q.result
-   @customers = Customer.order(created_at: 'desc').page(params[:page]).per(20)
- end
+    #時間別コール
+    @call_ng = @calls.where("statu LIKE ?","%NG%")
+    #9時台
+    @call_total_9 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "09:00:00" }.select { |call| l(call.created_at, format: :prepare) < "09:59:59" }.count
+    @call_total_b9 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "00:00:00" }.select { |call| l(call.created_at, format: :prepare) < '00:59:59' }.count
+    @call_called_9 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "09:00:00" }.select { |call| l(call.created_at, format: :prepare) < "09:59:59" }.count
+    @call_called_b9 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "00:00:00" }.select { |call| l(call.created_at, format: :prepare) < '00:59:59' }.count
+    @call_absence_9 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "09:00:00" }.select { |call| l(call.created_at, format: :prepare) < "09:59:59" }.count
+    @call_absence_b9 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "00:00:00" }.select { |call| l(call.created_at, format: :prepare) < '00:59:59' }.count
+    @call_prospect_9 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "09:00:00" }.select { |call| l(call.created_at, format: :prepare) < "09:59:59" }.count
+    @call_prospect_b9 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "00:00:00" }.select { |call| l(call.created_at, format: :prepare) < '00:59:59' }.count
+    @call_app_9 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "09:00:00" }.select { |call| l(call.created_at, format: :prepare) < "09:59:59" }.count
+    @call_app_b9 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "00:00:00" }.select { |call| l(call.created_at, format: :prepare) < '00:59:59' }.count
+    @call_ng_9 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "09:00:00" }.select { |call| l(call.created_at, format: :prepare) < "09:59:59" }.count
+    @call_ng_b9 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "00:00:00" }.select { |call| l(call.created_at, format: :prepare) < '00:59:59' }.count
 
- def extraction
-   @q = Customer.ransack(params[:q])
-   @customers = @q.result
-   @customers = Customer.where(tel: nil).page(params[:page]).per(20)
- end
+    #10時台
+    @call_total_10 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "10:00:00" }.select { |call| l(call.created_at, format: :prepare) < "10:59:59" }.count
+    @call_total_b10 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "01:00:00" }.select { |call| l(call.created_at, format: :prepare) < "01:59:59" }.count
+    @call_called_10 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "10:00:00" }.select { |call| l(call.created_at, format: :prepare) < "10:59:59" }.count
+    @call_called_b10 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "01:00:00" }.select { |call| l(call.created_at, format: :prepare) < "01:59:59" }.count
+    @call_absence_10 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "10:00:00" }.select { |call| l(call.created_at, format: :prepare) < "10:59:59" }.count
+    @call_absence_b10 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "01:00:00" }.select { |call| l(call.created_at, format: :prepare) < "01:59:59" }.count
+    @call_prospect_10 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "10:00:00" }.select { |call| l(call.created_at, format: :prepare) < "10:59:59" }.count
+    @call_prospect_b10 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "01:00:00" }.select { |call| l(call.created_at, format: :prepare) < "01:59:59" }.count
+    @call_app_10 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "10:00:00" }.select { |call| l(call.created_at, format: :prepare) < "10:59:59" }.count
+    @call_app_b10 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "01:00:00" }.select { |call| l(call.created_at, format: :prepare) < "01:59:59" }.count
+    @call_ng_10 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "10:00:00" }.select { |call| l(call.created_at, format: :prepare) < "10:59:59" }.count
+    @call_ng_b10 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "01:00:00" }.select { |call| l(call.created_at, format: :prepare) < '01:59:59' }.count
 
- def mail
-   @q = Customer.ransack(params[:q])
-   @customers = @q.result
-   @customers = Customer.where.not(mail: nil).page(params[:page]).per(20)
- end
+    #11時台
+    @call_total_11 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "11:00:00" }.select { |call| l(call.created_at, format: :prepare) < "11:59:59" }.count
+    @call_total_b11 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "02:00:00" }.select { |call| l(call.created_at, format: :prepare) < "02:59:59" }.count
+    @call_called_11 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "11:00:00" }.select { |call| l(call.created_at, format: :prepare) < "11:59:59" }.count
+    @call_called_b11 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "02:00:00" }.select { |call| l(call.created_at, format: :prepare) < "02:59:59" }.count
+    @call_absence_11 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "11:00:00" }.select { |call| l(call.created_at, format: :prepare) < "11:59:59" }.count
+    @call_absence_b11 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "02:00:00" }.select { |call| l(call.created_at, format: :prepare) < "02:59:59" }.count
+    @call_prospect_11 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "11:00:00" }.select { |call| l(call.created_at, format: :prepare) < "11:59:59" }.count
+    @call_prospect_b11 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "02:00:00" }.select { |call| l(call.created_at, format: :prepare) < "02:59:59" }.count
+    @call_app_11 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "11:00:00" }.select { |call| l(call.created_at, format: :prepare) < "11:59:59" }.count
+    @call_app_b11 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "02:00:00" }.select { |call| l(call.created_at, format: :prepare) < "02:59:59" }.count
+    @call_ng_11 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "11:00:00" }.select { |call| l(call.created_at, format: :prepare) < "11:59:59" }.count
+    @call_ng_b11 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "02:00:00" }.select { |call| l(call.created_at, format: :prepare) < '02:59:59' }.count
+
+    #13時台
+    @call_total_13 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "13:00:00" }.select { |call| l(call.created_at, format: :prepare) < "13:59:59" }.count
+    @call_total_b13 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "04:00:00" }.select { |call| l(call.created_at, format: :prepare) < "04:59:59" }.count
+    @call_called_13 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "13:00:00" }.select { |call| l(call.created_at, format: :prepare) < "13:59:59" }.count
+    @call_called_b13 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "04:00:00" }.select { |call| l(call.created_at, format: :prepare) < "04:59:59" }.count
+    @call_absence_13 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "13:00:00" }.select { |call| l(call.created_at, format: :prepare) < "13:59:59" }.count
+    @call_absence_b13 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "04:00:00" }.select { |call| l(call.created_at, format: :prepare) < "04:59:59" }.count
+    @call_prospect_13 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "13:00:00" }.select { |call| l(call.created_at, format: :prepare) < "13:59:59" }.count
+    @call_prospect_b13 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "04:00:00" }.select { |call| l(call.created_at, format: :prepare) < "04:59:59" }.count
+    @call_app_13 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "13:00:00" }.select { |call| l(call.created_at, format: :prepare) < "13:59:59" }.count
+    @call_app_b13 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "04:00:00" }.select { |call| l(call.created_at, format: :prepare) < "04:59:59" }.count
+    @call_ng_13 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "13:00:00" }.select { |call| l(call.created_at, format: :prepare) < "13:59:59" }.count
+    @call_ng_b13 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "04:00:00" }.select { |call| l(call.created_at, format: :prepare) < '04:59:59' }.count
+
+    #14時台
+    @call_total_14 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "14:00:00" }.select { |call| l(call.created_at, format: :prepare) < "14:59:59" }.count
+    @call_total_b14 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "05:00:00" }.select { |call| l(call.created_at, format: :prepare) < "05:59:59" }.count
+    @call_called_14 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "14:00:00" }.select { |call| l(call.created_at, format: :prepare) < "14:59:59" }.count
+    @call_called_b14 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "05:00:00" }.select { |call| l(call.created_at, format: :prepare) < "05:59:59" }.count
+    @call_absence_14 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "14:00:00" }.select { |call| l(call.created_at, format: :prepare) < "14:59:59" }.count
+    @call_absence_b14 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "05:00:00" }.select { |call| l(call.created_at, format: :prepare) < "05:59:59" }.count
+    @call_prospect_14 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "14:00:00" }.select { |call| l(call.created_at, format: :prepare) < "14:59:59" }.count
+    @call_prospect_b14 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "05:00:00" }.select { |call| l(call.created_at, format: :prepare) < "05:59:59" }.count
+    @call_app_14 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "14:00:00" }.select { |call| l(call.created_at, format: :prepare) < "14:59:59" }.count
+    @call_app_b14 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "05:00:00" }.select { |call| l(call.created_at, format: :prepare) < "05:59:59" }.count
+    @call_ng_14 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "14:00:00" }.select { |call| l(call.created_at, format: :prepare) < "14:59:59" }.count
+    @call_ng_b14 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "05:00:00" }.select { |call| l(call.created_at, format: :prepare) < '05:59:59' }.count
+
+    #15時台
+    @call_total_15 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "15:00:00" }.select { |call| l(call.created_at, format: :prepare) < "15:59:59" }.count
+    @call_total_b15 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "06:00:00" }.select { |call| l(call.created_at, format: :prepare) < "06:59:59" }.count
+    @call_called_15 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "15:00:00" }.select { |call| l(call.created_at, format: :prepare) < "15:59:59" }.count
+    @call_called_b15 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "06:00:00" }.select { |call| l(call.created_at, format: :prepare) < "06:59:59" }.count
+    @call_absence_15 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "15:00:00" }.select { |call| l(call.created_at, format: :prepare) < "15:59:59" }.count
+    @call_absence_b15 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "06:00:00" }.select { |call| l(call.created_at, format: :prepare) < "06:59:59" }.count
+    @call_prospect_15 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "15:00:00" }.select { |call| l(call.created_at, format: :prepare) < "15:59:59" }.count
+    @call_prospect_b15 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "06:00:00" }.select { |call| l(call.created_at, format: :prepare) < "06:59:59" }.count
+    @call_app_15 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "15:00:00" }.select { |call| l(call.created_at, format: :prepare) < "15:59:59" }.count
+    @call_app_b15 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "06:00:00" }.select { |call| l(call.created_at, format: :prepare) < "06:59:59" }.count
+    @call_ng_15 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "15:00:00" }.select { |call| l(call.created_at, format: :prepare) < "15:59:59" }.count
+    @call_ng_b15 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "06:00:00" }.select { |call| l(call.created_at, format: :prepare) < '06:59:59' }.count
+
+    #16時台
+    @call_total_16 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "16:00:00" }.select { |call| l(call.created_at, format: :prepare) < "16:59:59" }.count
+    @call_total_b16 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "07:00:00" }.select { |call| l(call.created_at, format: :prepare) < "07:59:59" }.count
+    @call_called_16 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "16:00:00" }.select { |call| l(call.created_at, format: :prepare) < "16:59:59" }.count
+    @call_called_b16 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "07:00:00" }.select { |call| l(call.created_at, format: :prepare) < "07:59:59" }.count
+    @call_absence_16 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "16:00:00" }.select { |call| l(call.created_at, format: :prepare) < "16:59:59" }.count
+    @call_absence_b16 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "07:00:00" }.select { |call| l(call.created_at, format: :prepare) < "07:59:59" }.count
+    @call_prospect_16 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "16:00:00" }.select { |call| l(call.created_at, format: :prepare) < "16:59:59" }.count
+    @call_prospect_b16 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "07:00:00" }.select { |call| l(call.created_at, format: :prepare) < "07:59:59" }.count
+    @call_app_16 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "16:00:00" }.select { |call| l(call.created_at, format: :prepare) < "16:59:59" }.count
+    @call_app_b16 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "07:00:00" }.select { |call| l(call.created_at, format: :prepare) < "07:59:59" }.count
+    @call_ng_16 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "16:00:00" }.select { |call| l(call.created_at, format: :prepare) < "16:59:59" }.count
+    @call_ng_b16 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "07:00:00" }.select { |call| l(call.created_at, format: :prepare) < '07:59:59' }.count
+
+    #17時台
+    @call_total_17 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "17:00:00" }.select { |call| l(call.created_at, format: :prepare) < "17:59:59" }.count
+    @call_total_b17 = @call_month_basic.select { |call| l(call.created_at, format: :prepare) >= "08:00:00" }.select { |call| l(call.created_at, format: :prepare) < "08:59:59" }.count
+    @call_called_17 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "17:00:00" }.select { |call| l(call.created_at, format: :prepare) < "17:59:59" }.count
+    @call_called_b17 = @call_count_called.select { |call| l(call.created_at, format: :prepare) >= "08:00:00" }.select { |call| l(call.created_at, format: :prepare) < "08:59:59" }.count
+    @call_absence_17 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "17:00:00" }.select { |call| l(call.created_at, format: :prepare) < "17:59:59" }.count
+    @call_absence_b17 = @call_count_absence.select { |call| l(call.created_at, format: :prepare) >= "08:00:00" }.select { |call| l(call.created_at, format: :prepare) < "08:59:59" }.count
+    @call_prospect_17 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "17:00:00" }.select { |call| l(call.created_at, format: :prepare) < "17:59:59" }.count
+    @call_prospect_b17 = @call_count_prospect.select { |call| l(call.created_at, format: :prepare) >= "08:00:00" }.select { |call| l(call.created_at, format: :prepare) < "08:59:59" }.count
+    @call_app_17 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "17:00:00" }.select { |call| l(call.created_at, format: :prepare) < "17:59:59" }.count
+    @call_app_b17 = @call_count_app.select { |call| l(call.created_at, format: :prepare) >= "08:00:00" }.select { |call| l(call.created_at, format: :prepare) < "08:59:59" }.count
+    @call_ng_17 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "17:00:00" }.select { |call| l(call.created_at, format: :prepare) < "17:59:59" }.count
+    @call_ng_b17 = @call_ng.select { |call| l(call.created_at, format: :prepare) >= "08:00:00" }.select { |call| l(call.created_at, format: :prepare) < '08:59:59' }.count
+    @admins = Admin.all
+    @users = User.all
+    #statu内容簡素化
+    @call_count = @calls.where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month)
+    #detail calls
+
+    @detailcalls = Customer2.joins(:calls).select('calls.id')
+
+    call_attributes = ["customer_id" ,"statu", "time", "comment", "created_at","updated_at"]
+    generate_call =
+      CSV.generate(headers:true) do |csv|
+        csv << call_attributes
+        Call.all.each do |task|
+          csv << call_attributes.map{|attr| task.send(attr)}
+        end
+      end
+    respond_to do |format|
+      format.html
+      format.csv{ send_data generate_call, filename: "calls-#{Time.zone.now.strftime('%Y%m%d%S')}.csv" }
+    end
+  end
+
+  def import
+    cnt = Customer.import(params[:file])
+    redirect_to customers_url, notice:"#{cnt}件登録されました。"
+  end
+
+  def call_import
+    cnt = Call.call_import(params[:call_file])
+    redirect_to customers_url, notice:"#{cnt}件登録されました。"
+  end
+
+  def confirm
+    @customer = Customer.new(customer_params)
+    if @customer.valid?
+      render :action =>  'confirm', notice: 'メッセージが送信されました。'
+    else
+      render :action => 'index', notice: 'メッセージが送信出来ませんでした。'
+    end
+  end
+
+  def thanks
+    @customer = Customer.find(params[:id])
+    CustomerMailer.received_email(@customer).deliver
+    CustomerMailer.send_email(@customer).deliver
+  end
+
+  def sfa
+    @q = Customer.ransack(params[:q])
+    @customers = @q.result
+    @customers = Customer.where(choice: "SFA").page(params[:page]).per(20)
+  end
+
+  def list
+    @q = Customer.ransack(params[:q])
+    @customers = @q.result
+    @customers = Customer.order(created_at: 'desc').page(params[:page]).per(20)
+  end
+
+  def extraction
+    @q = Customer.ransack(params[:q])
+    @customers = @q.result
+    @customers = Customer.where(tel: nil).page(params[:page]).per(20)
+  end
+
+  def mail
+    @q = Customer.ransack(params[:q])
+    @customers = @q.result
+    @customers = Customer.where.not(mail: nil).page(params[:page]).per(20)
+  end
 
   private
     def customer_params

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -12,8 +12,6 @@ class Customer < ApplicationRecord
   validates :tel, :exclusion => ["%080", "%090", "%0120", "%0088", "%070"], with: /^[0-9\-]+$/, on: :update
   validates :address, presence: true, on: :update
 
-
-
 #customer_import
   def self.import(file)
       save_cont = 0

--- a/app/views/customers/_show.html.erb
+++ b/app/views/customers/_show.html.erb
@@ -144,7 +144,7 @@
 			<th>削除</th>
 		</tr>
 		<tr>
-		<% @customer.calls.each do |call| %>
+		<% @customer.calls.includes([:admin, :user]).each do |call| %>
 			<td><%= call.created_at %></td>
 			<td>
           <%= call.admin&.user_name %>

--- a/app/views/customers/_show.html.erb
+++ b/app/views/customers/_show.html.erb
@@ -125,7 +125,6 @@
 </table>
 <%end%>
 </div>
-<%end%>
 
 <table width="100%" class="space">
 		<col width="15%">

--- a/app/views/customers/analytics.html.erb
+++ b/app/views/customers/analytics.html.erb
@@ -21,34 +21,34 @@
     <th>永久NG</th>
   </tr>
   <tr>
-    <% @users.each do |user| %>
-    <th><%= user.user_name %></th>
-    <td><%= user.calls.where(statu: "着信留守").count %></td>
-    <td><%= user.calls.where(statu: "担当者不在").count %></td>
-    <td><%= user.calls.where(statu: "見込").count %></td>
-    <td><%= user.calls.where(statu: "コロナ見込").count %></td>
-    <td><%= user.calls.where(statu: "折返待").count %></td>
-    <td><%= user.calls.where(statu: "APP").count %></td>
-    <td><%= user.calls.where(statu: "キャンセル").count %></td>
-    <td><%= user.calls.where(statu: "フロントNG").count %></td>
-    <td><%= user.calls.where(statu: "根本的NG").count %></td>
-    <td><%= user.calls.where(statu: "永久NG").count %></td>
+    <!% @users.each do |user| %>
+    <th><!%= user.user_name %></th>
+    <td><!%= user.calls.where(statu: "着信留守").count %></td>
+    <td><!%= user.calls.where(statu: "担当者不在").count %></td>
+    <td><!%= user.calls.where(statu: "見込").count %></td>
+    <td><!%= user.calls.where(statu: "コロナ見込").count %></td>
+    <td><!%= user.calls.where(statu: "折返待").count %></td>
+    <td><!%= user.calls.where(statu: "APP").count %></td>
+    <td><!%= user.calls.where(statu: "キャンセル").count %></td>
+    <td><!%= user.calls.where(statu: "フロントNG").count %></td>
+    <td><!%= user.calls.where(statu: "根本的NG").count %></td>
+    <td><!%= user.calls.where(statu: "永久NG").count %></td>
   </tr>
   <tr>
     <th></th>
-    <td><%= number_to_percentage(user.calls.where(statu: "着信留守").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "担当者不在").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "見込").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "コロナ見込").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "折返待").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "APP").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "キャンセル").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "フロントNG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "根本的NG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(user.calls.where(statu: "永久NG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "着信留守").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "担当者不在").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "見込").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "コロナ見込").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "折返待").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "APP").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "キャンセル").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "フロントNG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "根本的NG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(user.calls.where(statu: "永久NG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
   </tr>
-<% end %>
-</table>--!>
+<!% end %>
+</table>-->
 
 <table class="header-table space" width="90%">
   <tr>
@@ -104,20 +104,32 @@
     <th>NG</th>
   </tr>
   <tr>
-    <td><%= @call_count.where(statu: "着信留守").count %></td>
-    <td><%= @call_count.where(statu: "担当者不在").count %></td>
-    <td><%= @call_count.where(statu: "見込").count %></td>
-    <td><%= @call_count.where(statu: "APP").count %></td>
-    <td><%= @call_count.where(statu: "キャンセル").count %></td>
-    <td><%= @call_count.where(statu: "NG").count %></td>
+    <!--<td><!%= @call_count.where(statu: "着信留守").count %></td>
+    <td><!%= @call_count.where(statu: "担当者不在").count %></td>
+    <td><!%= @call_count.where(statu: "見込").count %></td>
+    <td><!%= @call_count.where(statu: "APP").count %></td>
+    <td><!%= @call_count.where(statu: "キャンセル").count %></td>
+    <td><!%= @call_count.where(statu: "NG").count %></td>-->
+    <td><%= @call_count_called %></td>
+    <td><%= @call_count_absence %></td>
+    <td><%= @call_count_prospect %></td>
+    <td><%= @call_count_app %></td>
+    <td><%= @call_count_cancel %></td>
+    <td><%= @call_count_ng %></td>
   </tr>
   <tr>
-    <td><%= number_to_percentage(@call_count.where(statu: "着信留守").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count.where(statu: "担当者不在").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count.where(statu: "見込").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count.where(statu: "APP").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count.where(statu: "キャンセル").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count.where(statu: "NG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <!--<td><!%= number_to_percentage(@call_count.where(statu: "着信留守").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(@call_count.where(statu: "担当者不在").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(@call_count.where(statu: "見込").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(@call_count.where(statu: "APP").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(@call_count.where(statu: "キャンセル").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
+    <td><!%= number_to_percentage(@call_count.where(statu: "NG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>-->
+    <td><%= number_to_percentage(@call_count_called / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_absence / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_prospect / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_app / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_cancel / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_ng / @call_count_month.to_f * 100, precision: 1 ) %></td>
   </tr>
 </table>
 <br>

--- a/app/views/customers/analytics.html.erb
+++ b/app/views/customers/analytics.html.erb
@@ -104,32 +104,20 @@
     <th>NG</th>
   </tr>
   <tr>
-    <!--<td><!%= @call_count.where(statu: "着信留守").count %></td>
-    <td><!%= @call_count.where(statu: "担当者不在").count %></td>
-    <td><!%= @call_count.where(statu: "見込").count %></td>
-    <td><!%= @call_count.where(statu: "APP").count %></td>
-    <td><!%= @call_count.where(statu: "キャンセル").count %></td>
-    <td><!%= @call_count.where(statu: "NG").count %></td>-->
-    <td><%= @call_count_called %></td>
-    <td><%= @call_count_absence %></td>
-    <td><%= @call_count_prospect %></td>
-    <td><%= @call_count_app %></td>
-    <td><%= @call_count_cancel %></td>
-    <td><%= @call_count_ng %></td>
+    <td><%= @call_count_called.count %></td>
+    <td><%= @call_count_absence.count %></td>
+    <td><%= @call_count_prospect.count %></td>
+    <td><%= @call_count_app.count %></td>
+    <td><%= @call_count_cancel.count %></td>
+    <td><%= @call_count_ng.count %></td>
   </tr>
   <tr>
-    <!--<td><!%= number_to_percentage(@call_count.where(statu: "着信留守").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><!%= number_to_percentage(@call_count.where(statu: "担当者不在").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><!%= number_to_percentage(@call_count.where(statu: "見込").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><!%= number_to_percentage(@call_count.where(statu: "APP").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><!%= number_to_percentage(@call_count.where(statu: "キャンセル").count / @call_count.count.to_f * 100, precision: 1 ) %></td>
-    <td><!%= number_to_percentage(@call_count.where(statu: "NG").count / @call_count.count.to_f * 100, precision: 1 ) %></td>-->
-    <td><%= number_to_percentage(@call_count_called / @call_count_month.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count_absence / @call_count_month.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count_prospect / @call_count_month.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count_app / @call_count_month.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count_cancel / @call_count_month.to_f * 100, precision: 1 ) %></td>
-    <td><%= number_to_percentage(@call_count_ng / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_called.count / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_absence.count / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_prospect.count / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_app.count / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_cancel.count / @call_count_month.to_f * 100, precision: 1 ) %></td>
+    <td><%= number_to_percentage(@call_count_ng.count / @call_count_month.to_f * 100, precision: 1 ) %></td>
   </tr>
 </table>
 <br>
@@ -227,107 +215,107 @@
   </tr>
   <tr>
     <th>09:00~10:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '09:00:00','09:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '00:00:00','00:59:59').count.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_called_9 / @call_total_9.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b9 / @call_total_b9.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_9 / @call_total_9.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b9 / @call_total_b9.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_9 / @call_total_9.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b9 / @call_total_b9.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_9 / @call_total_9.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b9 / @call_total_b9.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_ng_9 / @call_total_9.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b9 / @call_total_b9.to_f * 100, precision: 1) %>）</td>
   </tr>
   <tr>
     <th>10:00~11:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '10:00:00','10:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '01:00:00','01:59:59').count.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_called_10 / @call_total_10.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b10 / @call_total_b10.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_10 / @call_total_10.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b10 / @call_total_b10.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_10 / @call_total_10.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b10 / @call_total_b10.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_10 / @call_total_10.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b10 / @call_total_b10.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_ng_10 / @call_total_10.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b10 / @call_total_b10.to_f * 100, precision: 1) %>）</td>
   </tr>
   <tr>
     <th>11:00~12:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '11:00:00','11:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '02:00:00','02:59:59').count.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_called_11 / @call_total_11.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b11 / @call_total_b11.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_11 / @call_total_11.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b11 / @call_total_b11.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_11 / @call_total_11.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b11 / @call_total_b11.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_11 / @call_total_11.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b11 / @call_total_b11.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_ng_11 / @call_total_11.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b11 / @call_total_b11.to_f * 100, precision: 1) %>）</td>
   </tr>
   <tr>
     <th>13:00~14:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '13:00:00','13:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '04:00:00','04:59:59').count.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_called_13 / @call_total_13.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b13 / @call_total_b13.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_13 / @call_total_13.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b13 / @call_total_b13.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_13 / @call_total_13.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b13 / @call_total_b13.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_13 / @call_total_13.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b13 / @call_total_b13.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_ng_13 / @call_total_13.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b13 / @call_total_b13.to_f * 100, precision: 1) %>）</td>
   </tr>
   <tr>
     <th>14:00~15:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '14:00:00','14:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '05:00:00','05:59:59').count.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_called_14 / @call_total_14.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b14 / @call_total_b14.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_14 / @call_total_14.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b14 / @call_total_b14.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_14 / @call_total_14.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b14 / @call_total_b14.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_14 / @call_total_14.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b14 / @call_total_b14.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_ng_14 / @call_total_14.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b14 / @call_total_b14.to_f * 100, precision: 1) %>）</td>
   </tr>
   <tr>
     <th>15:00~16:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '15:00:00','15:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '06:00:00','06:59:59').count.to_f * 100, precision: 1) %>）</td>
+     <td><%= number_to_percentage(@call_called_15 / @call_total_15.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b15 / @call_total_b15.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_15 / @call_total_15.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b15 / @call_total_b15.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_15 / @call_total_15.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b15 / @call_total_b15.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_15 / @call_total_15.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b15 / @call_total_b15.to_f * 100, precision: 1) %>）</td>
+     <td><%= number_to_percentage(@call_ng_15 / @call_total_15.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b15 / @call_total_b15.to_f * 100, precision: 1) %>）</td>
   </tr>
   <tr>
     <th>16:00~17:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '16:00:00','16:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '07:00:00','07:59:59').count.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_called_16 / @call_total_16.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b16 / @call_total_b16.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_16 / @call_total_16.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b16 / @call_total_b16.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_16 / @call_total_16.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b16 / @call_total_b16.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_16 / @call_total_16.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b16 / @call_total_b16.to_f * 100, precision: 1) %>）</td>
+   <td><%= number_to_percentage(@call_ng_16 / @call_total_16.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b16 / @call_total_b16.to_f * 100, precision: 1) %>）</td>
   </tr>
   <tr>
     <th>17:00~18:00</th>
-    <td><%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "着信留守").where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-      （<%= number_to_percentage(@calls.where(statu: "担当者不在").where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%見込%").where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where(statu: "APP").where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count.to_f * 100, precision: 1) %>）</td>
-    <td><%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '17:00:00','17:59:59').where('created_at > ?', Time.current.beginning_of_month).where('created_at < ?', Time.current.end_of_month).count.to_f * 100, precision: 1) %>
-    　（<%= number_to_percentage(@calls.where("statu LIKE ?","%NG%").where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count / @calls.where('time(created_at) >= ? and time(created_at) < ?', '08:00:00','08:59:59').count.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_called_17 / @call_total_17.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_called_b17 / @call_total_b17.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_absence_17 / @call_total_17.to_f * 100, precision: 1) %>
+      （<%= number_to_percentage(@call_absence_b17 / @call_total_b17.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_prospect_17 / @call_total_17.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_prospect_b17 / @call_total_b17.to_f * 100, precision: 1) %>）</td>
+    <td><%= number_to_percentage(@call_app_17 / @call_total_17.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_app_b17 / @call_total_b17.to_f * 100, precision: 1) %>）</td>
+     <td><%= number_to_percentage(@call_ng_17 / @call_total_17.to_f * 100, precision: 1) %>
+    　（<%= number_to_percentage(@call_ng_b17 / @call_total_b17.to_f * 100, precision: 1) %>）</td>
   </tr>
 </table>
 <br>

--- a/app/views/customers/index.html.slim
+++ b/app/views/customers/index.html.slim
@@ -32,7 +32,7 @@
           | アップデート日
         th
           | 編集/削除
-    - @customers.each_with_index do |customer, index|
+    - @customers.includes(:last_call).each_with_index do |customer, index|
       tr
         td
           = check_box_tag "deletes[#{customer.id}]", customer.id

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -39,57 +39,57 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
   date:
     abbr_day_names:
-    - 日
-    - 月
-    - 火
-    - 水
-    - 木
-    - 金
-    - 土
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
     abbr_month_names:
-    -
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
     day_names:
-    - 日曜日
-    - 月曜日
-    - 火曜日
-    - 水曜日
-    - 木曜日
-    - 金曜日
-    - 土曜日
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
     formats:
       default: "%Y/%m/%d"
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
     month_names:
-    -
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
     order:
-    - :year
-    - :month
-    - :day
+      - :year
+      - :month
+      - :day
   datetime:
     distance_in_words:
       about_x_hours:
@@ -200,9 +200,9 @@ ja:
           quadrillion: 千兆
           thousand: 千
           trillion: 兆
-          unit: ''
+          unit: ""
       format:
-        delimiter: ''
+        delimiter: ""
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -216,11 +216,11 @@ ja:
           tb: TB
     percentage:
       format:
-        delimiter: ''
+        delimiter: ""
         format: "%n%"
     precision:
       format:
-        delimiter: ''
+        delimiter: ""
   support:
     array:
       last_word_connector: 、
@@ -233,4 +233,5 @@ ja:
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       short: "%y/%m/%d %H:%M"
       xs: "%H:%M"
+      prepare: "%H:%M:%S"
     pm: 午後


### PR DESCRIPTION
**実装内容**
・customers/indexのN+1問題改善
・customers/_showのエラー改善
・customers/_showのN+1問題改善
・analyticsのviewページの内容を整理しcontrollerに移動。コードを改善しSQL発行回数を減少。

**できるようになること（ユーザ目線）**
・customersのindexとshowページの速度改善
・analyticsページの速度改善
　→**改善前**
　　SQLクエリ発行数：209個
　　analytics.html.erb表示までの時間：約131.2ms
　　View表示までの時間：約193.2ms, Active_Recordにかかる時間：約19.5ms  =>  約246ms
　→**改善後**
　　SQLクエリ発行数：26個
　　analytics.html.erb表示までの時間：約38.3ms
　　View表示までの時間：約97.7ms, Active_Recordにかかる時間：約5.1ms  =>  約147ms


**動作確認**
・bullet(gem)を使用し、N+1問題改善を確認
・analyticsページの正常表示及び速度改善を確認

**その他**