### PR TITLE
再コール通知見直し

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -68,12 +68,11 @@ class CustomersController < ApplicationController
       last_call = last_call.where("calls.time <= ?", @last_call_params[:time_to]) if !@last_call_params[:time_to].blank?
       last_call = last_call.where("calls.created_at >= ?", @last_call_params[:created_at_from]) if !@last_call_params[:created_at_from].blank?
       last_call = last_call.where("calls.created_at <= ?", @last_call_params[:created_at_to]) if !@last_call_params[:created_at_to].blank?
-      last_call_customer_ids = last_call.pluck(:customer_id)
     end
     @customer = Customer.find(params[:id])
     @q = Customer.ransack(params[:q]) || Customer.ransack(params[:last_call])
     @customers = @q.result || @q.result.includes(:last_call)
-    @customers = @customers.where(id: last_call) if last_call
+    @customers = @customers.where( id: last_call )  if last_call
     @call = Call.new
     @prev_customer = @customers.where("customers.id < ?", @customer.id).last
     @next_customer = @customers.where("customers.id > ?", @customer.id).first

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -35,6 +35,11 @@ class Call < ApplicationRecord
     call_count_today.where(statu: "APP")
   }
 
+  scope :unread_notification, -> {
+    where.not(time: nil)
+      .where('latest_confirmed_time is null or time >= latest_confirmed_time')
+  }
+
   #call_import
     def  self.call_import(call_file)
       save_cnt = 0

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -20,36 +20,45 @@
   </style>
 
   <script>
-    var currenttime = function(){
-      var date = new Date();
-      format_str = 'YYYY-MM-DD hh:mm';
-      format_str = format_str.replace(/YYYY/g, date.getFullYear());
-      format_str = format_str.replace(/MM/g, ('0' + (date.getMonth() + 1)).slice(-2));
-      format_str = format_str.replace(/DD/g, ('0' + date.getDate()).slice(-2));
-      format_str = format_str.replace(/hh/g, ('0' + date.getHours()).slice(-2));
-      format_str = format_str.replace(/mm/g, ('0' + date.getMinutes()).slice(-2));
-      var user = gon.current_user;
-      $(document).ready(function(){
-        user.forEach(function( c ){
-          var called = new Date(c.time);
-          format_str1 = 'YYYY-MM-DD hh:mm';
-          format_str1 = format_str1.replace(/YYYY/g, called.getFullYear());
-          format_str1 = format_str1.replace(/MM/g, ('0' + (called.getMonth() + 1)).slice(-2));
-          format_str1 = format_str1.replace(/DD/g, ('0' + called.getDate()).slice(-2));
-          format_str1 = format_str1.replace(/hh/g, ('0' + called.getHours()).slice(-2));
-          format_str1 = format_str1.replace(/mm/g, ('0' + called.getMinutes()).slice(-2));
-          if(format_str1 === format_str){
-              $("#myToast").css( 'display', 'block' );
-              document.getElementById("edit_area").onclick = function(){
-                window.open('/customers/' + c.customer_id, "お客様情報ページへ", '_blank');
-              };
-          } else {
-            $('#myToast').css( 'display', 'none' );
-          }
-        });
+  $(document).ready(function() {
+    var calls = gon.current_user;
+    var nextCall = null;
+
+    var showToast = function(){
+      $("#myToast").css( 'display', 'block' );
+    }
+
+    var hideToast = function () {
+      $('#myToast').css('display', 'none');
+    }
+
+    var regist = function () {
+      var latestCallTime = sessionStorage.getItem('latestCallTime');
+
+      nextCall = calls.find(function (call) {
+        return !latestCallTime || latestCallTime < (new Date(call.time)).getTime()
       });
+
+      if (!nextCall) return;
+
+      var delay = (new Date(nextCall.time)).getTime() - Date.now();
+
+      if (delay <= 0) {
+        showToast();
+      }
+
+      return setTimeout(showToast, delay);
+    }
+
+    document.getElementById("edit_area").onclick = function(){
+      hideToast();
+      sessionStorage.setItem('latestCallTime', new Date(nextCall.time).getTime());
+      window.open('/customers/' + nextCall.customer_id + '?notified_call_id=' + nextCall.id, "お客様情報ページへ", '_blank');
+      regist();
     };
-    setInterval(currenttime, 10000);
+
+    regist();
+  });
   </script>
 </head>
 <body>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/db/migrate/20220118075432_add_latest_confirmed_time_to_call.rb
+++ b/db/migrate/20220118075432_add_latest_confirmed_time_to_call.rb
@@ -1,0 +1,7 @@
+class AddLatestConfirmedTimeToCall < ActiveRecord::Migration[5.1]
+  def change
+    add_column :calls, :latest_confirmed_time, :datetime
+    Call.where('time is not null').update_all(latest_confirmed_time: Time.zone.now - 3.day)
+    add_index :calls, [:user_id, :latest_confirmed_time, :time]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220114212658) do
+ActiveRecord::Schema.define(version: 20220118075432) do
 
   create_table "admins", force: :cascade do |t|
     t.string "user_name", default: "", null: false
@@ -36,10 +36,12 @@ ActiveRecord::Schema.define(version: 20220114212658) do
     t.integer "admin_id"
     t.integer "crm_id"
     t.integer "user_id"
+    t.datetime "latest_confirmed_time"
     t.index ["admin_id"], name: "index_calls_on_admin_id"
     t.index ["crm_id"], name: "index_calls_on_crm_id"
     t.index ["customer_id", "created_at"], name: "index_calls_on_customer_id_and_created_at"
     t.index ["customer_id"], name: "index_calls_on_customer_id"
+    t.index ["user_id", "latest_confirmed_time", "time"], name: "index_calls_on_user_id_and_latest_confirmed_time_and_time"
     t.index ["user_id"], name: "index_calls_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
再通知を設定したコールについて、時間がすぎたものをトーストで表示する。
下記変更点
- 最長過去１分のみが対象だったものを、時間が過ぎた通知でも対象とする
- サーバでコール対象の通知を最大１分キャッシュする
- 既読管理追加
  - 過去３日経過したものは既読状態として、通知を行わない（マイグレーションで既読日時設定）
  - 通知のリンクをクリックした際に対象のコールを既読状態にし、再通知から対象外とする