### PR TITLE
puma のスレッド数を調整

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 1 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.


### PR DESCRIPTION
## 概要
puma をシングルスレッドにすることで、エラーが回避かつ速度の改善に見込めそう。

## TODO
- 現状 worker の数が 2 になっているが、sqlite が複数プロセスからの書き込みに耐えているのか確認が必要
- puma の設定が git 管理されていないので、git 管理する