### PR TITLE
お問い合わせページをスクレイピング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ doc/
 /db/development.sqlite3
 
 .env
+
+auto_contact/config
+auto_contact/screenshots

--- a/Gemfile
+++ b/Gemfile
@@ -107,3 +107,5 @@ gem 'kaminari-bootstrap', '~> 3.0.1'
 gem 'sitemap_generator'
 
 gem 'lograge'
+
+gem 'open_uri_redirections'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-x64-mingw32)
       racc (~> 1.4)
+    open_uri_redirections (0.2.1)
     orm_adapter (0.5.0)
     pdf-core (0.9.0)
     polyamorous (2.3.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   meta-tags
+  open_uri_redirections
   pry-rails
   puma (~> 4.3)
   rails (~> 5.1.6)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -139,7 +139,12 @@ class Customer < ApplicationRecord
   enum status: {draft: 0, published: 1}
 
   def contact_url
-    @contact_url ||= scraping.contact_from(url_2) || scraping.contact_from(url)
+    @contact_url ||=
+      scraping.contact_from(url_2) ||
+      scraping.contact_from(url) ||
+      scraping.contact_from(
+        scraping.google_search([company, address, tel].compact.join(' '))
+      )
   end
 
   private

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -138,4 +138,13 @@ class Customer < ApplicationRecord
 
   enum status: {draft: 0, published: 1}
 
+  def contact_url
+    @contact_url ||= scraping.contact_from(url_2) || scraping.contact_from(url)
+  end
+
+  private
+
+  def scraping
+    @scraping ||= Scraping.new
+  end
 end

--- a/lib/scraping.rb
+++ b/lib/scraping.rb
@@ -1,0 +1,102 @@
+require 'open-uri'
+require 'nokogiri'
+
+class Scraping
+  BLACKLIST_DOMAINS = [
+    'jp.indeed.com',
+    'xn--pckua2a7gp15o89zb.com',
+  ]
+
+  #
+  # url から問い合わせ先の URL を取得する
+  #
+  # @param [String] url URL
+  #
+  # @return [String] 問い合わせ URL
+  #
+  def contact_from(url)
+    return nil if url.blank?
+
+    customer_url = URI.parse(URI.encode(url))
+
+    return nil if BLACKLIST_DOMAINS.include?(customer_url.host)
+
+    document = create_document(url)
+
+    return nil unless document
+
+    document.css('a').each do |anchor|
+      next unless anchor.get_attribute('href')
+
+      # anchor.inner_html.encode('utf-8') + anchor.get_attribute('alt')
+      if anchor.inner_html.encode('utf-8') =~ /問い合わせ|問合せ/
+        href = URI.parse(URI.encode(anchor.get_attribute('href')))
+
+        if !href.host && !href.scheme
+          unless href.path[0] == '/'
+            href.path = customer_url.path + href.path
+          end
+
+          href.scheme = customer_url.scheme
+          href.host = customer_url.host
+        end
+
+        return href.to_s
+      end
+    end
+
+    nil
+  rescue Net::OpenTimeout, Net::ReadTimeout
+    nil
+  rescue Encoding::CompatibilityError
+    nil
+  rescue ArgumentError
+    nil
+  end
+
+  #
+  # contact_url から入力要素を抽出する
+  #
+  # @param [String] url URL
+  #
+  # @return [Hash] 入力要素
+  #
+  def input_attributes(url)
+    document = create_document(url)
+
+    return nil unless document
+
+    form = document.css('form')
+    elements = form.css('input', 'textarea', 'select').map do |element|
+      element unless ['hidden', 'submit', 'reset'].include?(element.get_attribute('type'))
+    end.compact
+
+    elements.map do |element|
+      {
+        'id' => element.get_attribute('id'),
+        'name' => element.get_attribute('name'),
+        'class' => element.get_attribute('class'),
+        'type' => element.get_attribute('type'),
+        'value' => element.get_attribute('value'),
+      }
+    end
+  end
+
+  private
+
+  def create_document(url)
+    Nokogiri::HTML(URI.open(url, :allow_redirections => :all))
+  rescue Encoding::CompatibilityError
+    Nokogiri::HTML(URI.open(url, 'r:Shift_JIS', :allow_redirections => :all))
+  rescue OpenURI::HTTPError, SocketError, Errno::ENOENT
+    Rails.logger.error $!
+
+    nil
+  rescue ArgumentError
+    Rails.logger.error $!.backtrace.join("\n")
+
+    nil
+  end
+
+  attr_reader :customer
+end

--- a/lib/tasks/auto_contact.rake
+++ b/lib/tasks/auto_contact.rake
@@ -1,0 +1,38 @@
+require 'scraping'
+
+namespace :auto_contact do
+  desc 'お問い合わせページの確認'
+  task check: :environment do
+    scraping = Scraping.new
+
+    Customer.limit(10).each do |customer|
+      contact = customer.attributes.compact.filter { |k, v| ['created_at', 'updated_at'].exclude?(k) }
+
+      if customer.contact_url
+        contact['contact_url'] = customer.contact_url
+
+        contact['attributes'] = scraping.input_attributes(customer.contact_url)
+      end
+
+      config_path = Rails.root.join('auto_contact', 'config', 'customers')
+
+      contact_url_missing_path = config_path.join('contact_url_missing', "#{customer.id}.yaml")
+      attributes_missing_path = config_path.join('attributes_missing', "#{customer.id}.yaml")
+      success_path = config_path.join('success', "#{customer.id}.yaml")
+
+      [contact_url_missing_path, attributes_missing_path, success_path].each do |path|
+        path.delete if path.exist?
+      end
+
+      if contact['contact_url']
+        if contact['attributes']
+          success_path.write(contact.to_yaml)
+        else
+          attributes_missing_path.write(contact.to_yaml)
+        end
+      else
+        contact_url_missing_path.write(contact.to_yaml)
+      end
+    end
+  end
+end

--- a/lib/tasks/auto_contact.rake
+++ b/lib/tasks/auto_contact.rake
@@ -5,7 +5,7 @@ namespace :auto_contact do
   task check: :environment do
     scraping = Scraping.new
 
-    Customer.limit(10).each do |customer|
+    Customer.limit(1000).each do |customer|
       contact = customer.attributes.compact.filter { |k, v| ['created_at', 'updated_at'].exclude?(k) }
 
       if customer.contact_url


### PR DESCRIPTION
## 概要
お問い合わせページの特定対応。

#### rake タスク

lib/tasks/auto_contact.rake の中で Customer の 1000 件を固定で対象としているため、対象を変更の上実行してください。

コマンド:

```
$ bundle exec rails auto_contact:check
```

コマンドを実行すると、customer ごとに下記の実行結果が出力されます。

- config/customers/success/*
  - 問い合わせページが正しく見つかった
- config/customers/contact_url_missing/*
  - 問い合わせページが見つからない
- config/customers/attributes_missing/*
  - 問い合わせページは見つけたが、問い合わせフォームが見つけれない
  