### PR TITLE
フィードバック対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,6 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:user_name, :select])
   end
 
-
     # set for devise login redirector
     def after_sign_in_path_for(resource)
       case resource
@@ -66,7 +65,13 @@ class ApplicationController < ActionController::Base
       when Worker
         worker_path(current_worker)
       when Sender
-        myself_path
+        if current_sender.inquiries.empty?
+          flash[:notice] = "案件の内容を登録してください"
+
+          new_inquiry_path
+        else
+          myself_path
+        end
       when Client
         client_path
       else

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -1,59 +1,70 @@
 class InquiriesController < ApplicationController
-  before_action :authenticate_sender!, only: [:edit, :new]
-    def index
-      @inquiries = Inquiry.all
-    end
+  before_action :authenticate_sender!
 
-    def show
-      @inquiry = Inquiry.find(params[:id])
-    end
+  def index
+    @inquiries = current_sender.inquiries
+  end
 
-    def new
-      @inquiry = Inquiry.new
-    end
+  def show
+    @inquiry = current_sender.inquiries.find(params[:id])
+  end
 
-    def create
-      @inquiry = Inquiry.new(inquiry_params)
-      if @inquiry.save
-        redirect_to inquiries_path
-      else
-        render 'new'
+  def new
+    @inquiry = current_sender.inquiries.new
+  end
+
+  def create
+    @inquiry = current_sender.inquiries.new(inquiry_params)
+    if @inquiry.save
+      unless current_sender.default_inquiry
+        current_sender.default_inquiry = @inquiry
+        current_sender.save!
       end
-    end
 
-    def edit
-      @inquiry = Inquiry.find(params[:id])
-    end
-
-    def destroy
-      @inquiry = Inquiry.find(params[:id])
-      @inquiry.destroy
-       redirect_to inquiries_path
-    end
-
-    def update
-      @inquiry = Inquiry.find(params[:id])
-      if @inquiry.update(inquiry_params)
-        redirect_to inquiries_path
+      if sender_signed_in?
+        redirect_to myself_path
       else
-        render 'edit'
+        fail 'TOOD'
       end
+    else
+      render 'new'
     end
+  end
 
-    private
-    def inquiry_params
-      params.require(:inquiry).permit(
-        :headline, #案件名
-        :from_company, #会社名
-        :person, #担当者
-        :person_kana, #タントウシャ
-        :from_tel, #電話番号
-        :from_fax, #FAX番号
-        :from_mail, #メールアドレス
-        :url, #HP
-        :address, #住所
-        :title, #件名
-        :content #本文
-        )
+  def edit
+    @inquiry = current_sender.inquiries.find(params[:id])
+  end
+
+  def destroy
+    @inquiry = current_sender.inquiries.find(params[:id])
+    @inquiry.destroy
+      redirect_to inquiries_path
+  end
+
+  def update
+    @inquiry = current_sender.inquiries.find(params[:id])
+    if @inquiry.update(inquiry_params)
+      redirect_to inquiries_path
+    else
+      render 'edit'
     end
+  end
+
+  private
+
+  def inquiry_params
+    params.require(:inquiry).permit(
+      :headline, #案件名
+      :from_company, #会社名
+      :person, #担当者
+      :person_kana, #タントウシャ
+      :from_tel, #電話番号
+      :from_fax, #FAX番号
+      :from_mail, #メールアドレス
+      :url, #HP
+      :address, #住所
+      :title, #件名
+      :content #本文
+    )
+  end
 end

--- a/app/controllers/okurite_controller.rb
+++ b/app/controllers/okurite_controller.rb
@@ -19,6 +19,7 @@ class OkuriteController < ApplicationController
 
   def create
     @sender.send_contact!(
+      params[:callback_code],
       params[:okurite_id],
       current_worker&.id,
       params[:inquiry_id],
@@ -44,13 +45,13 @@ class OkuriteController < ApplicationController
 
     @prev_customer = @customers.where("customers.id < ?", @customer.id).last
     @next_customer = @customers.where("customers.id > ?", @customer.id).first
-    @contact_tracking = ContactTracking.find_by(
-      code: @sender.generate_code(@customer.id),
-    )
+    @contact_tracking = @sender.contact_trackings.where(customer: @customer).order(sended_at: :desc).first
 
     contactor = Contactor.new(@inquiry, @sender)
 
     @contact_url = params['force_google'] ? @customer.google_search_url : @customer.contact_url
+
+    @callback_code = @sender.generate_code
 
     gon.typings = contactor.try_typings(@contact_url, @customer.id)
   end

--- a/app/controllers/okurite_controller.rb
+++ b/app/controllers/okurite_controller.rb
@@ -41,15 +41,16 @@ class OkuriteController < ApplicationController
 
   def preview
     @customer = Customer.find(params[:okurite_id])
-    @inquiry = Inquiry.first
+
+    @inquiry = @sender.default_inquiry
 
     @prev_customer = @customers.where("customers.id < ?", @customer.id).last
     @next_customer = @customers.where("customers.id > ?", @customer.id).first
-    @contact_tracking = @sender.contact_trackings.where(customer: @customer).order(sended_at: :desc).first
+    @contact_tracking = @sender.contact_trackings.where(customer: @customer).order(created_at: :desc).first
 
     contactor = Contactor.new(@inquiry, @sender)
 
-    @contact_url = params['force_google'] ? @customer.google_search_url : @customer.contact_url
+    @contact_url = @customer.contact_url
 
     @callback_code = @sender.generate_code
 

--- a/app/controllers/senders/registrations_controller.rb
+++ b/app/controllers/senders/registrations_controller.rb
@@ -7,8 +7,8 @@ class Senders::RegistrationsController < Devise::RegistrationsController
 
   private
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:user_name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_name, :rate_limit])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:user_name, :rate_limit])
   end
   # GET /resource/sign_up
   # def new

--- a/app/controllers/senders/registrations_controller.rb
+++ b/app/controllers/senders/registrations_controller.rb
@@ -5,11 +5,6 @@ class Senders::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_account_update_params, only: [:update]
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
-  def after_sign_up_path_for(resource)
-    "/sender/#{currend_sender.id}"
-  end
-
   private
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:user_name])
@@ -68,9 +63,11 @@ class Senders::RegistrationsController < Devise::RegistrationsController
   protected
 
   # The path used after sign up.
-   def after_sign_up_path_for(resource)
-     sender_path(id: current_sender.id)
-   end
+  def after_sign_up_path_for(resource)
+    flash[:notice] = "案件の内容を登録してください"
+
+    new_inquiry_path
+  end
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)

--- a/app/models/contact_tracking.rb
+++ b/app/models/contact_tracking.rb
@@ -5,7 +5,7 @@ class ContactTracking < ApplicationRecord
   belongs_to :worker, optional: true
 
   validates :code, uniqueness: true, presence: true
-  validates :status, presence: true, inclusion: { in: %w(送信済 送信不可 送信NG) }
+  validates :status, presence: true, inclusion: { in: %w(送信済 送信不可 営業NG) }
 
   def success?
     status == '送信済'

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -4,7 +4,13 @@ class Inquiry < ApplicationRecord
   has_many :contact_trackings
 
   validates :headline, presence: true
+  validates :from_company, presence: true
+  validates :person, presence: true
+  validates :person_kana, presence: true
+  validates :from_tel, presence: true
+  validates :from_mail, presence: true
   validates :url, presence: true
+  validates :title, presence: true
   validates :content, presence: true, format: { with: /\${callback_url}/ }
 
   def parse_content(sender, code)

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -3,7 +3,11 @@ require 'contactor'
 class Inquiry < ApplicationRecord
   has_many :contact_trackings
 
-  def parse_content(sender, customer_id)
-    content.gsub('${callback_url}', sender.callback_url(customer_id))
+  validates :headline, presence: true
+  validates :url, presence: true
+  validates :content, presence: true, format: { with: /\${callback_url}/ }
+
+  def parse_content(sender, code)
+    content.gsub('${callback_url}', sender.callback_url(code))
   end
 end

--- a/app/models/sender.rb
+++ b/app/models/sender.rb
@@ -4,33 +4,30 @@ class Sender < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  belongs_to :default_inquiry, foreign_key: :default_inquiry_id, class_name: 'Inquiry', optional: true
+
   has_many :counts
   has_many :contact_trackings
+  has_many :inquiries
 
-  def callback_url(customer_id)
-    Rails.application.routes.url_helpers.callback_url(t: generate_code(customer_id))
+  def callback_url(code)
+    Rails.application.routes.url_helpers.callback_url(t: code)
   end
 
-  def generate_code(customer_id)
-    Digest::MD5.hexdigest({
-      sender_id: id,
-      customer_id: customer_id,
-    }.to_json)
+  def generate_code
+    SecureRandom.hex
   end
 
-  def send_contact!(customer_id, worker_id, inquiry_id, contact_url, status)
-    contact_tracking = contact_trackings.find_or_initialize_by(
-      code: generate_code(customer_id),
-    )
-
-    contact_tracking.attributes = {
+  def send_contact!(code, customer_id, worker_id, inquiry_id, contact_url, status)
+    contact_tracking = contact_trackings.new(
+      code: code,
       customer_id: customer_id,
       worker_id: worker_id,
       inquiry_id: inquiry_id,
       contact_url: contact_url,
       sended_at: status == '送信済' && Time.zone.now,
       status: status,
-    }
+    )
 
     contact_tracking.save!
   end

--- a/app/views/inquiries/index.html.slim
+++ b/app/views/inquiries/index.html.slim
@@ -8,13 +8,13 @@
        th 案件タイトル
        th 最終更新日
        th
-      tr
       - @inquiries.each do |inquiry|
-        td
-          = link_to inquiry.headline, inquiry_path(inquiry)
-        td
-          = inquiry.updated_at.strftime("%Y年%m月%d日 %H時%M分")
-        td
-          = link_to '編集', edit_inquiry_path(inquiry), class: 'btn btn-success'
-          = link_to '削除',
-          -                        inquiry_path(inquiry),method: :delete,class: 'btn btn-success',data: { confirm: '本当に削除しますか？'}
+        tr
+          td
+            = link_to inquiry.headline, inquiry_path(inquiry)
+          td
+            = inquiry.updated_at.strftime("%Y年%m月%d日 %H時%M分")
+          td
+            = link_to '編集', edit_inquiry_path(inquiry), class: 'btn btn-success'
+            = link_to '削除',
+            - inquiry_path(inquiry),method: :delete,class: 'btn btn-success',data: { confirm: '本当に削除しますか？'}

--- a/app/views/okurite/preview.html.erb
+++ b/app/views/okurite/preview.html.erb
@@ -123,6 +123,7 @@ $(function () {
           <%= form_tag sender_okurite_contact_url(okurite_id: @customer), method: :post do %>
             <%= hidden_field_tag :contact_url, @contact_url %>
             <%= hidden_field_tag :inquiry_id, @inquiry.id %>
+            <%= hidden_field_tag :callback_code, @callback_code %>
             <%= hidden_field_tag :next_customer_id, @next_customer&.id %>
 
             <div class="input-group">
@@ -154,11 +155,11 @@ $(function () {
             <dt class="col-12">メールアドレス</dt>
             <dd class="col-12"><pre><%= @inquiry.from_mail %></pre></dd>
             <dt class="col-12">URL</dt>
-            <dd class="col-12"><pre><%= @sender.callback_url(@customer.id) %></pre></dd>
+            <dd class="col-12"><pre><%= @sender.callback_url(@callback_code) %></pre></dd>
             <dt class="col-12">件名</dt>
             <dd class="col-12"><pre><%= @inquiry.title %></pre></dd>
             <dt class="col-12">本文</dt>
-            <dd class="col-12"><pre><%= @inquiry.parse_content(@sender, @customer.id) %></pre></dd>
+            <dd class="col-12"><pre><%= @inquiry.parse_content(@sender, @callback_code) %></pre></dd>
           </dl>
         <% else %>
           <div class="alert alert-danger" role="alert">

--- a/app/views/okurite/preview.html.erb
+++ b/app/views/okurite/preview.html.erb
@@ -85,12 +85,16 @@ $(function () {
             <% if @contact_url %>
               <%= link_to '別タブで表示', @contact_url, target: :_blank  %><br>
             <% end %>
-            <%= link_to 'Google で再検索', sender_okurite_preview_path(okurite_id: @customer.id, q: params[:q]&.permit!, force_google: true) %>
+            <%=
+              link_to 'Google で再検索',
+              "https://www.google.co.jp/search?hl=ja&num=11&q=#{URI.encode_www_form_component([@customer.company, @customer.address, @customer.tel].join(' '))}",
+              target: :_blank
+            %>
           </td>
         </tr>
       </table>
 
-      <h4><%= link_to '送信履歴', inquiry_path(@inquiry), target: :_blank %></h4>
+      <h4><%= link_to '送信履歴', sender_path(@sender), target: :_blank %></h4>
 
       <table class="table table-striped">
         <col width="40%">
@@ -118,54 +122,54 @@ $(function () {
             </tr>
           <% end %>
         </table>
-      <% else %>
-        <% if @sender.rate_limit > @sender.contact_trackings.count %>
-          <%= form_tag sender_okurite_contact_url(okurite_id: @customer), method: :post do %>
-            <%= hidden_field_tag :contact_url, @contact_url %>
-            <%= hidden_field_tag :inquiry_id, @inquiry.id %>
-            <%= hidden_field_tag :callback_code, @callback_code %>
-            <%= hidden_field_tag :next_customer_id, @next_customer&.id %>
+      <% end %>
 
-            <div class="input-group">
-              <%= select_tag(
-                :status,
-                options_for_select(['送信済', '送信不可', '営業NG']),
-                class: 'custom-select'
-              )%>
+      <% if @sender.rate_limit > @sender.contact_trackings.count %>
+        <%= form_tag sender_okurite_contact_url(okurite_id: @customer), method: :post do %>
+          <%= hidden_field_tag :contact_url, @contact_url %>
+          <%= hidden_field_tag :inquiry_id, @inquiry.id %>
+          <%= hidden_field_tag :callback_code, @callback_code %>
+          <%= hidden_field_tag :next_customer_id, @next_customer&.id %>
 
-              <div class="input-group-append">
-                <%= submit_tag '確定', class: 'btn btn-outline-secondary', class:"btn btn-success" %>
-              </div>
+          <div class="input-group">
+            <%= select_tag(
+              :status,
+              options_for_select(['送信済', '送信不可', '営業NG']),
+              class: 'custom-select'
+            )%>
+
+            <div class="input-group-append">
+              <%= submit_tag '確定', class: 'btn btn-outline-secondary', class:"btn btn-success" %>
             </div>
-          <% end %>
-
-          <dl>
-            <dt class="col-12">会社名</dt>
-            <dd class="col-12"><pre><%= @inquiry.from_company %></pre></dd>
-            <dt class="col-12">担当者</dt>
-            <dd class="col-12"><pre><%= @inquiry.person %></pre></dd>
-            <dt class="col-12">タントウシャ</dt>
-            <dd class="col-12"><pre><%= @inquiry.person_kana %></pre></dd>
-            <dt class="col-12">電話番号</dt>
-            <dd class="col-12"><pre><%= @inquiry.from_tel %></pre></dd>
-            <dt class="col-12">FAX番号</dt>
-            <dd class="col-12"><pre><%= @inquiry.from_fax %></pre></dd>
-            <dt class="col-12">住所</dt>
-            <dd class="col-12"><pre><%= @inquiry.address %></pre></dd>
-            <dt class="col-12">メールアドレス</dt>
-            <dd class="col-12"><pre><%= @inquiry.from_mail %></pre></dd>
-            <dt class="col-12">URL</dt>
-            <dd class="col-12"><pre><%= @sender.callback_url(@callback_code) %></pre></dd>
-            <dt class="col-12">件名</dt>
-            <dd class="col-12"><pre><%= @inquiry.title %></pre></dd>
-            <dt class="col-12">本文</dt>
-            <dd class="col-12"><pre><%= @inquiry.parse_content(@sender, @callback_code) %></pre></dd>
-          </dl>
-        <% else %>
-          <div class="alert alert-danger" role="alert">
-            今月は上限に達しました
           </div>
         <% end %>
+
+        <dl>
+          <dt class="col-12">会社名</dt>
+          <dd class="col-12"><pre><%= @inquiry.from_company %></pre></dd>
+          <dt class="col-12">担当者</dt>
+          <dd class="col-12"><pre><%= @inquiry.person %></pre></dd>
+          <dt class="col-12">タントウシャ</dt>
+          <dd class="col-12"><pre><%= @inquiry.person_kana %></pre></dd>
+          <dt class="col-12">電話番号</dt>
+          <dd class="col-12"><pre><%= @inquiry.from_tel %></pre></dd>
+          <dt class="col-12">FAX番号</dt>
+          <dd class="col-12"><pre><%= @inquiry.from_fax %></pre></dd>
+          <dt class="col-12">住所</dt>
+          <dd class="col-12"><pre><%= @inquiry.address %></pre></dd>
+          <dt class="col-12">メールアドレス</dt>
+          <dd class="col-12"><pre><%= @inquiry.from_mail %></pre></dd>
+          <dt class="col-12">URL</dt>
+          <dd class="col-12"><pre><%= @sender.callback_url(@callback_code) %></pre></dd>
+          <dt class="col-12">件名</dt>
+          <dd class="col-12"><pre><%= @inquiry.title %></pre></dd>
+          <dt class="col-12">本文</dt>
+          <dd class="col-12"><pre><%= @inquiry.parse_content(@sender, @callback_code) %></pre></dd>
+        </dl>
+      <% else %>
+        <div class="alert alert-danger" role="alert">
+          今月は上限に達しました
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/senders/registrations/edit.html.erb
+++ b/app/views/senders/registrations/edit.html.erb
@@ -20,6 +20,11 @@
       <td> <%= f.text_field :user_name %></td>
     </tr>
     <tr>
+      <th>月間送信上限件数<span class="label label-blue">必須</span></br>
+            <small>1000</small></th>
+      <td> <%= f.number_field :rate_limit %></td>
+    </tr>
+    <tr>
       <th>ログインアドレス<span class="label label-blue">必須</span></br>
               <small>aaa@crold-valieat.jp</small></th>
       <td> <%= f.email_field :email, autofocus: true, autocomplete: "email" %></td>

--- a/app/views/senders/registrations/new.html.erb
+++ b/app/views/senders/registrations/new.html.erb
@@ -18,6 +18,11 @@
         <td> <%= f.text_field :user_name %></td>
       </tr>
       <tr>
+        <th>月間送信上限件数<span class="label label-blue">必須</span></br>
+              <small>1000</small></th>
+        <td> <%= f.number_field :rate_limit %></td>
+      </tr>
+      <tr>
         <th>ログインアドレス<span class="label label-blue">必須</span></br>
                 <small>aaa@crold-valieat.jp</small></th>
         <td> <%= f.email_field :email, autofocus: true, autocomplete: "email" %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,9 @@ Rails.application.routes.draw do
   devise_for :senders, controllers: {
     registrations: 'senders/registrations'
   }
-  resource :myself, only: :show, controller: :sender
+  resource :myself, only: :show, controller: :sender do
+    resources :inquiries, only: [:index]
+  end
   resources :senders, only: [:index, :show] do
     # okurite
     resources :okurite, only: [:index, :show] do
@@ -52,7 +54,7 @@ Rails.application.routes.draw do
   }
   resources :workers, only: [:show]
 
-  resources :inquiries #問い合わせいフォーム送信内容選択モデル
+  resources :inquiries, except: [:index] #問い合わせいフォーム送信内容選択モデル
   resources :skillsheets
   resources :matters
   resources :posts

--- a/db/migrate/20220410083432_add_sender_columns_to_inquiries.rb
+++ b/db/migrate/20220410083432_add_sender_columns_to_inquiries.rb
@@ -1,0 +1,6 @@
+class AddSenderColumnsToInquiries < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :inquiries, :sender
+    add_column :senders, :default_inquiry_id, :integer
+  end
+end

--- a/db/migrate/20220410083432_add_sender_columns_to_inquiries.rb
+++ b/db/migrate/20220410083432_add_sender_columns_to_inquiries.rb
@@ -1,5 +1,6 @@
 class AddSenderColumnsToInquiries < ActiveRecord::Migration[5.1]
   def change
+    change_column :senders, :rate_limit, :integer, default: nil
     add_reference :inquiries, :sender
     add_column :senders, :default_inquiry_id, :integer
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 20220410083432) do
     t.string "extraction_count"
     t.string "send_count"
     t.integer "worker_id"
+    t.index ["created_at", nil], name: "index_customers_on_created_at_and_statu"
     t.index ["created_at"], name: "index_customers_on_created_at"
     t.index ["worker_id"], name: "index_customers_on_worker_id"
   end
@@ -299,7 +300,7 @@ ActiveRecord::Schema.define(version: 20220410083432) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "rate_limit", default: 100
+    t.integer "rate_limit"
     t.integer "default_inquiry_id"
     t.index ["email"], name: "index_senders_on_email", unique: true
     t.index ["reset_password_token"], name: "index_senders_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220320063142) do
+ActiveRecord::Schema.define(version: 20220410083432) do
 
   create_table "admins", force: :cascade do |t|
     t.string "user_name", default: "", null: false
@@ -259,6 +259,8 @@ ActiveRecord::Schema.define(version: 20220320063142) do
     t.string "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sender_id"
+    t.index ["sender_id"], name: "index_inquiries_on_sender_id"
   end
 
   create_table "matters", force: :cascade do |t|
@@ -298,6 +300,7 @@ ActiveRecord::Schema.define(version: 20220320063142) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "rate_limit", default: 100
+    t.integer "default_inquiry_id"
     t.index ["email"], name: "index_senders_on_email", unique: true
     t.index ["reset_password_token"], name: "index_senders_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 修正内容

```
  ✔ コールバックのアクセスエラーの解決 @done(22-04-11 08:14)
  ✔ 上限送信数の登録（サインアップ、sender 自身で編集） @done(22-04-11 08:25)
  ✔ google検索をiFrame内で一番上の検索を表示するのでは無く、google検索一覧ページを新規ウィンドウで表示 @done(22-04-11 08:55)
  ✔ 送信結果登録を複数回行えるようにする @done(22-04-11 09:07)
  ✔ preview の送信履歴の遷移先を /senders/:id に修正 @done(22-04-11 09:07)
  ✔ Senders→inquiries（1対多）の導線を構築 @done(22-04-11 09:22)
  sender毎送信数・送信完了件数・送信不可件数・営業NG件数・送信率・月間送信数
  ✔ previewは送信完了の総合件数 @done(22-04-11 09:22)
```

## TODO

```
  ☐ 上限送信数の更新（admin）
  => 逆に sender の編集はもともとベースがあったので、対応しました。
  => admin は別で新規に作る想定なので、これから別途対応します。
  ☐ 送信数表示対応（一日の送信数・直近一週間の送信数）
  => 画面の作りが月単位で集計単位の粒度が違うので、表示方法は相談させてください
  ☐ Sendersの登録
  → https://tcare-customer-management.atlassian.net/browse/TCAR-25
  regstration/newはこのままで結構なので、マイページ内からSenders企業情報を登録するように出来れば。
  ☐ Workerのマイページ
  ☐ inquiries の admin、worker 対応
```